### PR TITLE
made the logo and title in the navbar smaller

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -13,6 +13,13 @@
     height: 100%;
     display: flex;
     align-items: center;
+    img {
+      height: 55px;
+      width: 55px;
+    }
+    h4 {
+      font-size: 20px;
+    }
   }
   a {
     color: rgba(0, 0, 0, 0.741);
@@ -32,7 +39,7 @@
       font-size: 25px;
     }
     #action {
-      font-size: 11px;
+      font-size: 10px;
     }
   }
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <% if user_signed_in? %>
   <div class="navbar px-3">
     <div class="logo-title">
-      <%= link_to image_tag("navbar_logo.png", alt: "navbar-logo", size: "70x70"), root_path %>
+      <%= link_to image_tag("navbar_logo.png", alt: "navbar-logo"), root_path %>
       <h4>DefendHer RUN</h4>
     </div>
     <div class="actions">


### PR DESCRIPTION
I made the title and the logo smaller, since on samsung the "sign up" and "log in" buttons on the navbar break because of not enough space.